### PR TITLE
FIx 'wrong type for ID: float64' issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ async function downloadTwitchVod(vodIdOrURL, options = {}) {
   }
   const vodId = isValidUrl(vodIdOrURL)
     ? vodIdOrURL.split("/").pop()
-    : vodIdOrURL;
+    : vodIdOrURL.toString();
   try {
     const vodCredentials = await fetchVodCredentials(vodId);
     const manifestVods = await fetchVodM3u8(vodId, vodCredentials);


### PR DESCRIPTION
Using the code in the README results in a `wrong type for ID: float64` error. 

It can be fixed by forcing the `vodIdOrURL` argument to a string in your ternary condition.